### PR TITLE
fix: import nimcrypto to allow tests to be run individually

### DIFF
--- a/tests/daggercontracts/testContracts.nim
+++ b/tests/daggercontracts/testContracts.nim
@@ -1,4 +1,5 @@
 import pkg/chronos
+import pkg/nimcrypto
 import daggercontracts
 import daggercontracts/testtoken
 import ./web3test


### PR DESCRIPTION
Without nimcrypto imported in to `testContracts`, it cannot be run independently from `testMarketplace` (which imports `nimcrypto`).

Co-authored-by: Michael Bradley <michaelsbradleyjr@gmail.com>